### PR TITLE
Добавлен вывод в панель сверху новых ресурсов.

### DIFF
--- a/521475369/interface/resource_groups/topbar_other_resource_groups.txt
+++ b/521475369/interface/resource_groups/topbar_other_resource_groups.txt
@@ -10,6 +10,8 @@ tb_others_group = {
 			sr_dark_matter
 			nanites
 			pr_psychosocial
+			pr_middle
+			pr_strong
 		}
 		onclick = market
 	}
@@ -22,7 +24,7 @@ tb_others_group = {
 		}
 		onclick = discoveries
 		show_only_if_owned = yes
-		additional_element_height = 25
+		additional_element_height = 75
 	}
 
 	localization = {
@@ -31,7 +33,7 @@ tb_others_group = {
 		"RESOURCE_GROUP_DEFAULT_NEG_DEC" = { balance < 0 stored >= 1000 stored < 10000 }
 		"RESOURCE_GROUP_DEFAULT_NEG_TOTAL_POS" = { total_balance >= 0 balance < 0 }
 		"RESOURCE_GROUP_DEFAULT_NEG" = { balance < 0 }
-		"RESOURCE_GROUP_DEFAULT_MAX_DEC" = { max > 0 stored >= max total_stored >=1000 total_stored < 10000 }
+		"RESOURCE_GROUP_DEFAULT_MAX_DEC" = { max > 0 stored >= max total_stored >= 1000 total_stored < 10000 }
 		"RESOURCE_GROUP_DEFAULT_MAX" = { max > 0 stored >= max }
 		"RESOURCE_GROUP_DEFAULT_DEC" = { stored >= 1000 stored < 10000 }
 	}


### PR DESCRIPTION
Additional Height изменён в следствие добавления новых ресов. В общем, в игре есть баг (или фича, я хз), когда при открытой панели сверху ресурсы в ней отображаются только при закрытии (в подсказке, появляющейся при наведении - всегда). Но просто так он не даёт увеличить окно, не знаю - почему, пришлось его увеличивать уже после нахождения артефактов.